### PR TITLE
Add physical-collider to spaceship

### DIFF
--- a/scribblings/game-engine.scrbl
+++ b/scribblings/game-engine.scrbl
@@ -32,7 +32,9 @@ Here's a full example:
   (sprite->entity (circle 20 "solid" "red")
                   #:name       "ship"
                   #:position   (posn 100 100)
-                  #:components (key-movement 5)))
+                  #:components
+                  (key-movement 5)
+                  (physical-collider)))
 
 
 (start-game (instructions WIDTH HEIGHT "Use arrow keys to move")


### PR DESCRIPTION
Without it the following error occurs when evaluating start-game:

; struct-copy: contract violation
;   expected: physical-collider?
;   given: #f
; Context:
;  /home/kristian/.racket/7.1/pkgs/game-engine/engine/core.rkt:1356:0 set-velocity
;  /home/kristian/.racket/7.1/pkgs/game-engine/engine/core.rkt:996:3
;  /home/kristian/.racket/7.1/pkgs/game-engine/engine/core.rkt:1004:0 tick-entity
;  /home/kristian/.racket/7.1/pkgs/game-engine/engine/core.rkt:1010:0 tick-entities38
;  /home/kristian/.racket/7.1/pkgs/game-engine/engine/core.rkt:1117:0 tick-once
;  /home/kristian/.racket/7.1/pkgs/game-engine/engine/core.rkt:1110:0 tick44
;  /home/kristian/.racket/7.1/pkgs/game-engine/engine/rendering.rkt:194:3 word-tick
;  /home/kristian/.racket/7.1/pkgs/lux/word.rkt:142:18
;  /home/kristian/.racket/7.1/pkgs/lux/word.rkt:84:0 call-with-chaos
;  /home/kristian/.racket/7.1/pkgs/game-engine/game-entities.rkt:23:0 start-game
;  (submod "/home/kristian/projects/ninja-game/main.rkt" main):1:1 [running body]